### PR TITLE
bump version of up version to avoid docker 25 bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ GO_SUBDIRS += cmd internal apis
 # Setup Kubernetes tools
 
 KIND_VERSION = v0.15.0
-UP_VERSION = v0.14.0
+UP_VERSION = v0.28.0
 UP_CHANNEL = stable
 UPTEST_VERSION = v0.2.1
 -include build/makelib/k8s_tools.mk


### PR DESCRIPTION
The original build process was based on Up v0.14.0, and it contains a bug that makes it incompatible with Docker 25.
A fix for that was proposed here: https://github.com/upbound/up/issues/416
And the fix made it into Up v0.28.0

This fix addresses the problem found in https://github.com/oracle-samples/crossplane-provider-oci/issues/25

Tested building the Xpkg successfully while before it was failing
