### PR TITLE
feat: Add support for security token auth

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,8 @@ export TERRAFORM_PROVIDER_SOURCE := oracle/oci
 export TERRAFORM_PROVIDER_REPO := https://github.com/oracle/terraform-provider-oci
 export TERRAFORM_PROVIDER_VERSION := 7.7.0
 export TERRAFORM_PROVIDER_DOWNLOAD_NAME := terraform-provider-oci
-export TERRAFORM_NATIVE_PROVIDER_BINARY := terraform-provider-oci_v7.7.0
-export TERRAFORM_PROVIDER_DOWNLOAD_URL_PREFIX := https://releases.hashicorp.com/terraform-provider-oci/7.7.0
+export TERRAFORM_NATIVE_PROVIDER_BINARY := terraform-provider-oci_v$(TERRAFORM_PROVIDER_VERSION)
+export TERRAFORM_PROVIDER_DOWNLOAD_URL_PREFIX := https://releases.hashicorp.com/terraform-provider-oci/$(TERRAFORM_PROVIDER_VERSION)
 export TERRAFORM_DOCS_PATH := website/docs/r
 
 export CROSSPLANE_PROVIDER_VERSION := 1.0
@@ -58,7 +58,7 @@ GO_SUBDIRS += cmd internal apis
 # Setup Kubernetes tools
 
 KIND_VERSION = v0.15.0
-UP_VERSION = v0.14.0
+UP_VERSION = v0.39.0
 UP_CHANNEL = stable
 UPTEST_VERSION = v0.2.1
 -include build/makelib/k8s_tools.mk

--- a/examples/providerconfig/secret.yaml.tmpl
+++ b/examples/providerconfig/secret.yaml.tmpl
@@ -25,3 +25,20 @@ stringData:
       "fingerprint": "",
       "region": ""
     }
+  # security token based auth is also supported 
+  # https://docs.oracle.com/en-us/iaas/Content/dev/terraform/configuring.htm#security-token-auth
+  #
+  # This token expires after one hour. Avoid using this authentication method when provisioning 
+  # of resources takes longer than one hour. For more information, 
+  # see https://docs.oracle.com/iaas/Content/API/SDKDocs/clitoken.htm#Refreshing_a_Token.
+  #
+  # for more information on token based authentication see 
+  # https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/clitoken.htm
+  # 
+  #credentials: |
+  #  {
+  #    "tenancy_ocid": "",
+  #    "region": "",
+  #    "auth": "SecurityToken",
+  #    "config_file_profile": ""
+  #  }

--- a/internal/clients/oci.go
+++ b/internal/clients/oci.go
@@ -64,12 +64,14 @@ func TerraformSetupBuilder(version, providerSource, providerVersion string) terr
 
 		// Set credentials in Terraform provider configuration.
 		ps.Configuration = map[string]interface{}{
-			"tenancy_ocid":     ociCreds["tenancy_ocid"],
-			"user_ocid":        ociCreds["user_ocid"],
-			"private_key":      ociCreds["private_key"],
-			"private_key_path": ociCreds["private_key_path"],
-			"fingerprint":      ociCreds["fingerprint"],
-			"region":           ociCreds["region"],
+			"tenancy_ocid":        ociCreds["tenancy_ocid"],
+			"user_ocid":           ociCreds["user_ocid"],
+			"private_key":         ociCreds["private_key"],
+			"private_key_path":    ociCreds["private_key_path"],
+			"fingerprint":         ociCreds["fingerprint"],
+			"region":              ociCreds["region"],
+			"auth":                ociCreds["auth"],
+			"config_file_profile": ociCreds["config_file_profile"],
 		}
 		return ps, nil
 	}


### PR DESCRIPTION
<!-- please add a type to the title of this PR (see https://www.conventionalcommits.org/en/v1.0.0/#summary), and delete this line and similar ones -->
<!-- the type will be either fix:, feat:, docs:, test: see https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional for a more exhaustive list -->

**What this PR does / why we need it**:
Updates the oci.go client to pass the `auth` and `config_file_profile` to terraform to allow users to use those fields to support SecurityToken: https://docs.oracle.com/en-us/iaas/Content/dev/terraform/configuring.htm#security-token-auth

Also update the version of `UP` to use. Otherwise the local build won't work and returns 
```
up: error: unable to calculate manifest: blob ... not found
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fix #25 
