### PR TITLE
fix: Remove "Cleanup Disk" step from the publish action

### DIFF
--- a/.github/workflows/publish-provider-packages.yaml
+++ b/.github/workflows/publish-provider-packages.yaml
@@ -53,17 +53,6 @@ jobs:
     needs: index
     runs-on: ubuntu-latest
     steps:
-      - name: Cleanup Disk
-        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
-        if: true
-        with:
-          android: true
-          dotnet: true
-          haskell: true
-          tool-cache: true
-          large-packages: false
-          swap-storage: false
-
       - name: Setup QEMU
         uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7 # v2
         with:


### PR DESCRIPTION
### Description of your changes
Removes the unapproved action step `Cleanup Disk`. This should allow the workflow to run.

Fixes #

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make generate` and committed the results (ideally in a separate commit). <!-- It's normal for this to appear to stall for several minutes with no visible output -->
- [X] Not made any manual changes to generated files, and verified this with `make check-diff`.

### How has this code been tested
Tested in a forked repo: https://github.com/joekr/crossplane-provider-oci/actions/runs/17333337460
<img width="1255" height="415" alt="image" src="https://github.com/user-attachments/assets/c06a98a8-34f3-4ab6-bb03-d7ab1391c95d" />


<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://github.com/oracle-samples/crossplane-provider-oci/blob/main/CONTRIBUTING.md
